### PR TITLE
FIX: Write Entries.Count prior to writing the entries of the StackMapTableAttribute.

### DIFF
--- a/src/Bali/Attributes/Writers/StackMapTableAttributeWriter.cs
+++ b/src/Bali/Attributes/Writers/StackMapTableAttributeWriter.cs
@@ -25,6 +25,7 @@ namespace Bali.Attributes.Writers
         {
             var stackMapFrameWriter = new StackMapFrameWriter(writer);
             
+            writer.WriteU2((ushort) attribute.Entries.Count);
             foreach (var frame in attribute.Entries)
                 stackMapFrameWriter.WriteFrame(frame);
         }


### PR DESCRIPTION
Closes #53 